### PR TITLE
Added some new information to the reporting record

### DIFF
--- a/draft-lear-opsawg-mud-reporter.mkd
+++ b/draft-lear-opsawg-mud-reporter.mkd
@@ -21,6 +21,15 @@ author:
     country: Switzerland
     phone: +41 44 878 9200
     email: lear@cisco.com
+ -
+    ins: M. Ranganathan
+    name: Mudumbai Ranganathan
+    org: National Institute of Standards and Technology
+    street:  100 Bureau Dr.
+    city: Gaithersburg
+    country:  U.S.A
+    phone: +1 301 975 2857
+    email: mranga@nist.gov
 
 normative:
    RFC6991:
@@ -55,8 +64,8 @@ getting the access it needs.  Some examples include:
  * The MUD file permits access only to same-manufacturer or model but
    there is none.
  * The MUD file permits access to a particular Internet service, but
-   the name of that service resolved to something that was not
-   permitted.
+   the name of that service has not been resolved (or name resolution 
+   failed).
  * The administrator overrode the recommendations in the MUD file.
 
 This memo sets out to provide manufacturers indications regarding what
@@ -227,8 +236,6 @@ The Reporter record format
 --------------------------
 
 ~~~~~~~~~
-
-
 <CODE BEGINS>file "ietf-mud-reporter@2019-06-21.yang"
 module ietf-mud-reporter {
   yang-version 1.1;
@@ -292,30 +299,30 @@ module ietf-mud-reporter {
 	  description
 	    "The MUD-URL for which the report is being sent.";
       }  
-     container mud-records {
+    container mud-records {
         description "individual records.";
 
-	leaf time {
+	 leaf time {
 	  type yang:timestamp;
 	  mandatory true;
 	  description "when this happened.";
 	  }
 
 	 leaf direction {
-     	    type enumerated {
-  	      enum to-device {
+       type enumerated {
+  	        enum to-device {
  	     	  description "packet was traveling toward the device";
-	     }
-	     enum from-device {
+	        }
+	       enum from-device {
 	     	  description "packet was traveling away from the device";
-	     }
          }
+    }
 
 	
 	leaf mycontrollers {
 	  type uint32;
 	  description "how many entries for my-controller.";
-	  }
+	 }
 
 	list controllers {
 	  key "uri";
@@ -327,6 +334,7 @@ module ietf-mud-reporter {
 	  leaf count {
 	       type uint32;
 	       description "number of devices serving this class.";
+      }
 	  leaf ipaddress {
 	       type inet:ip-address;
 	       description
@@ -350,6 +358,7 @@ module ietf-mud-reporter {
 	  leaf count {
 	       type uint32;
 	       description "number of devices serving this class.";
+      }
 	  leaf ipaddress {
 	       type inet:ip-address;
 	       description
@@ -375,7 +384,8 @@ module ietf-mud-reporter {
 	          "IP address of the controller.  Note that the MUD
 		   reporter MUST NOT transmit this contents of this
 		   node to the manufacturer.";
-	}	
+	  }	
+    }
 	list domains {
 	  key "hostname";
 	  description "list of hosts, and ip addresses if known.";
@@ -391,6 +401,47 @@ module ietf-mud-reporter {
        }
      }
   }
+
+
+  grouping class-drop-count {
+     description 
+          "Destination fields of acl violating  packet are classfied."; 
+
+     leaf manufacturer {
+       description "manufacturer name";
+       type string;
+     }
+
+     leaf model {
+       description "manufacturer name";
+       type string;
+     }
+
+     leaf local-networks {
+       description "this packet matches the local networks classification";
+       type boolean;
+     }
+
+     leaf controller {
+       description "controller name";
+       type string;
+     }
+
+     leaf drop-count {
+       description "number of packets dropped for this classification";
+        type uint32;
+     }
+  }
+
+  container drop-counts {
+     list packet-ddrops {
+        description "drop counts for packets in different classes, Packets that violate access rules are logged here. ";
+        uses class-drop-count;
+     }
+  }
+  
+  
+  
   grouping l3l4info {
      description "Various L3/L4 information that might cause a drop."
      leaf ipsrc {
@@ -416,16 +467,32 @@ module ietf-mud-reporter {
 	  description "destination port";
       }
    }
+ }
 }
 <CODE ENDS>
 ~~~~~~~~~
 
 
-RESTful interface
-=================
-
-Insert stuff here.
-
+RESTful interface at the collector
+==================================
+~~~~~~~~~
+<CODE BEGINS>file "ietf-mud-repor-collector@2019-06-21.yang"
+module mud-reporter-collector {
+    import ietf-mud-reporter {
+        prefix "reporter";
+    }
+    rpc post-mud-report {
+      description 
+         "Rpc interface that must be supported by collection point
+      input {
+        leaf mud-report {
+            type reporter:mud-reporter;
+        }
+      }
+    }
+}
+<CODE ENDS>
+~~~~~~~~~
 
 
 Examples

--- a/draft-lear-opsawg-mud-reporter.txt
+++ b/draft-lear-opsawg-mud-reporter.txt
@@ -4,8 +4,9 @@
 
 Network Working Group                                            E. Lear
 Internet-Draft                                             Cisco Systems
-Intended status: Standards Track                           June 21, 2019
-Expires: December 23, 2019
+Intended status: Standards Track                          M. Ranganathan
+Expires: December 29, 2019National Institute of Standards and Technology
+                                                           June 27, 2019
 
 
                    Reporting MUD behavior to vendors
@@ -33,7 +34,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 23, 2019.
+   This Internet-Draft will expire on December 29, 2019.
 
 Copyright Notice
 
@@ -52,8 +53,7 @@ Copyright Notice
 
 
 
-
-Lear                    Expires December 23, 2019               [Page 1]
+Lear & Ranganathan      Expires December 29, 2019               [Page 1]
 
 Internet-Draft                MUD Reporter                     June 2019
 
@@ -65,14 +65,15 @@ Table of Contents
      2.1.  The mud-reporter-extension augmentation to the MUD YANG
            model . . . . . . . . . . . . . . . . . . . . . . . . . .   4
      2.2.  The Reporter record format  . . . . . . . . . . . . . . .   6
-     2.3.  Operational matters . . . . . . . . . . . . . . . . . . .   9
-   3.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .   9
-   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
-   5.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   9
-     5.1.  Normative References  . . . . . . . . . . . . . . . . . .   9
-     5.2.  Informative References  . . . . . . . . . . . . . . . . .  10
-   Appendix A.  Changes from Earlier Versions  . . . . . . . . . . .  10
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  10
+   3.  RESTful interface at the collector  . . . . . . . . . . . . .  11
+   4.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .  11
+   5.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  11
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  12
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  12
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  12
+   Appendix A.  Changes from Earlier Versions  . . . . . . . . . . .  13
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  13
 
 1.  Introduction
 
@@ -90,8 +91,8 @@ Table of Contents
       there is none.
 
    o  The MUD file permits access to a particular Internet service, but
-      the name of that service resolved to something that was not
-      permitted.
+      the name of that service has not been resolved (or name resolution
+      failed).
 
    o  The administrator overrode the recommendations in the MUD file.
 
@@ -108,8 +109,7 @@ Table of Contents
 
 
 
-
-Lear                    Expires December 23, 2019               [Page 2]
+Lear & Ranganathan      Expires December 29, 2019               [Page 2]
 
 Internet-Draft                MUD Reporter                     June 2019
 
@@ -165,7 +165,7 @@ Internet-Draft                MUD Reporter                     June 2019
 
 
 
-Lear                    Expires December 23, 2019               [Page 3]
+Lear & Ranganathan      Expires December 29, 2019               [Page 3]
 
 Internet-Draft                MUD Reporter                     June 2019
 
@@ -221,7 +221,7 @@ Internet-Draft                MUD Reporter                     June 2019
 
 
 
-Lear                    Expires December 23, 2019               [Page 4]
+Lear & Ranganathan      Expires December 29, 2019               [Page 4]
 
 Internet-Draft                MUD Reporter                     June 2019
 
@@ -277,7 +277,7 @@ Internet-Draft                MUD Reporter                     June 2019
 
 
 
-Lear                    Expires December 23, 2019               [Page 5]
+Lear & Ranganathan      Expires December 29, 2019               [Page 5]
 
 Internet-Draft                MUD Reporter                     June 2019
 
@@ -297,178 +297,328 @@ Internet-Draft                MUD Reporter                     June 2019
 
 2.2.  The Reporter record format
 
+<CODE BEGINS>file "ietf-mud-reporter@2019-06-21.yang"
+module ietf-mud-reporter {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-mud-reporter";
+  prefix mud-reporter;
 
- <CODE BEGINS>file "ietf-mud-reporter@2019-06-21.yang"
- module ietf-mud-reporter {
-   yang-version 1.1;
-   namespace "urn:ietf:params:xml:ns:yang:ietf-mud-reporter";
-   prefix mud-reporter;
+  import ietf-inet-types {
+    prefix "inet";
+  }
 
-   import ietf-inet-types {
-     prefix "inet";
-   }
+  import ietf-yang-types {
+     prefix yang;
+  }
 
-   import ietf-yang-types {
-      prefix yang;
-   }
+  organization
+    "IETF OPSAWG (Ops Area) Working Group";
+  contact
+    "WG Web: http://tools.ietf.org/wg/opsawg/
+     WG List: opsawg@ietf.org
+     Author: Eliot Lear
+     lear@cisco.com
+    ";
+  description
 
-   organization
-     "IETF OPSAWG (Ops Area) Working Group";
-   contact
-     "WG Web: http://tools.ietf.org/wg/opsawg/
-      WG List: opsawg@ietf.org
-      Author: Eliot Lear
-      lear@cisco.com
-     ";
-   description
+    "This YANG module specifies the reporting format for MUD managers
+     to use when they are reporting to manufacturers.
 
-     "This YANG module specifies the reporting format for MUD managers
-      to use when they are reporting to manufacturers.
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
 
-      Copyright (c) 2019 IETF Trust and the persons identified as
-      authors of the code.  All rights reserved.
-
-      Redistribution and use in source and binary forms, with or
-      without modification, is permitted pursuant to, and subject to
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
 
 
 
-Lear                    Expires December 23, 2019               [Page 6]
+Lear & Ranganathan      Expires December 29, 2019               [Page 6]
 
 Internet-Draft                MUD Reporter                     June 2019
 
 
-      the license terms contained in, the Simplified BSD License set
-      forth in Section 4.c of the IETF Trust's Legal Provisions
-      Relating to IETF Documents
-        (https://trustee.ietf.org/license-info).
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+       (https://trustee.ietf.org/license-info).
 
-      This version of this YANG module is part of RFC XXXX
-      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
-       for full legal notices.
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+      for full legal notices.
 
-      The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
-      NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
-     'MAY', and 'OPTIONAL' in this document are to be interpreted as
-      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
-     they appear in all capitals, as shown here.
- ";
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+    'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+    they appear in all capitals, as shown here.
+";
 
-   revision 2019-06-21 {
-     description
-       "Initial proposed standard.";
-     reference "RFC XXXX: Extension for MUD Reporting";
-   }
+  revision 2019-06-21 {
+    description
+      "Initial proposed standard.";
+    reference "RFC XXXX: Extension for MUD Reporting";
+  }
 
-   container mud-reporter {
-      description "MUD reporter container.";
+  container mud-reporter {
+     description "MUD reporter container.";
 
-      leaf mudurl {
-           type inet:uri;
-           mandatory true;
-           description
-             "The MUD-URL for which the report is being sent.";
-       }
-      container mud-records {
-         description "individual records.";
+     leaf mudurl {
+          type inet:uri;
+          mandatory true;
+          description
+            "The MUD-URL for which the report is being sent.";
+      }
+    container mud-records {
+        description "individual records.";
 
          leaf time {
-           type yang:timestamp;
-           mandatory true;
-           description "when this happened.";
-           }
+          type yang:timestamp;
+          mandatory true;
+          description "when this happened.";
+          }
 
-         leaf mycontrollers {
-           type uint32;
-           description "how many entries for my-controller.";
-           }
+         leaf direction {
+       type enumerated {
+                enum to-device {
+                  description "packet was traveling toward the device";
+                }
+               enum from-device {
+                  description "packet was traveling away from the device";
+         }
+    }
 
-         list controllers {
-           key "uri";
-           description "list of controllers and how many there were.";
 
 
-
-Lear                    Expires December 23, 2019               [Page 7]
+Lear & Ranganathan      Expires December 29, 2019               [Page 7]
 
 Internet-Draft                MUD Reporter                     June 2019
 
 
-           leaf uri {
-                type inet:uri;
-                description "the class URI of this controller";
-                }
-           leaf count {
-                type uint32;
-                description "number of devices serving this class.";
-           }
+        leaf mycontrollers {
+          type uint32;
+          description "how many entries for my-controller.";
          }
-         leaf samemanufacturers {
-              type uint32;
-              description "number of devices matching same
-                           manufacturer.";
-         }
-         list manufacturers {
-           key "authority";
-           description "list of models and how many there were.";
-           leaf authority {
-                type inet:host;
-                description "the manufacturer domain";
-                }
-           leaf count {
-                type uint32;
-                description "number of devices serving this class.";
-           }
-         }
-         list models {
-           key "uri";
-           description "list of models and how many there were.";
-           leaf uri {
-                type inet:uri;
-                description "the URI of this model";
-                }
-           leaf count {
-                type uint32;
-                description "number of devices serving this class.";
-           }
-         }
-         list domains {
-           key "hostname";
-           description "list of hosts, and ip addresses if known.";
-           leaf hostname {
-                type inet:host;
-                description "the host listed";
-                }
-           leaf-list ip-addresses {
-                type inet:ip-address;
-                description "ipv4 or v6 address mapping for this host if
 
-
-
-Lear                    Expires December 23, 2019               [Page 8]
-
-Internet-Draft                MUD Reporter                     June 2019
-
-
-                             known.";
-           }
+        list controllers {
+          key "uri";
+          description "list of controllers and how many there were.";
+          leaf uri {
+               type inet:uri;
+               description "the class URI of this controller";
+               }
+          leaf count {
+               type uint32;
+               description "number of devices serving this class.";
+      }
+          leaf ipaddress {
+               type inet:ip-address;
+               description
+                  "IP address of the controller.  Note that the MUD
+                   reporter MUST NOT transmit this contents of this
+                   node to the manufacturer.";
+          }
         }
+        leaf samemanufacturers {
+             type uint32;
+             description "number of devices matching same
+                          manufacturer.";
+        }
+        list manufacturers {
+          key "authority";
+          description "list of models and how many there were.";
+          leaf authority {
+               type inet:host;
+               description "the manufacturer domain";
+               }
+          leaf count {
+               type uint32;
+               description "number of devices serving this class.";
+      }
+          leaf ipaddress {
+               type inet:ip-address;
+               description
+                  "IP address of the controller.  Note that the MUD
+                   reporter MUST NOT transmit this contents of this
+                   node to the manufacturer.";
+          }
+        }
+
+
+
+Lear & Ranganathan      Expires December 29, 2019               [Page 8]
+
+Internet-Draft                MUD Reporter                     June 2019
+
+
+        list models {
+          key "uri";
+          description "list of models and how many there were.";
+          leaf uri {
+               type inet:uri;
+               description "the URI of this model";
+               }
+          leaf count {
+               type uint32;
+               description "number of devices serving this class.";
+          }
+          leaf ipaddress {
+               type inet:ip-address;
+               description
+                  "IP address of the controller.  Note that the MUD
+                   reporter MUST NOT transmit this contents of this
+                   node to the manufacturer.";
+          }
+    }
+        list domains {
+          key "hostname";
+          description "list of hosts, and ip addresses if known.";
+          leaf hostname {
+               type inet:host;
+               description "the host listed";
+               }
+          leaf-list ip-addresses {
+               type inet:ip-address;
+               description "ipv4 or v6 address mapping for this host if
+                            known.";
+          }
+       }
+     }
+  }
+
+
+  grouping class-drop-count {
+     description
+          "Destination fields of acl violating  packet are classfied.";
+
+     leaf manufacturer {
+       description "manufacturer name";
+       type string;
+     }
+
+     leaf model {
+       description "manufacturer name";
+       type string;
+
+
+
+Lear & Ranganathan      Expires December 29, 2019               [Page 9]
+
+Internet-Draft                MUD Reporter                     June 2019
+
+
+     }
+
+     leaf local-networks {
+       description "this packet matches the local networks classification";
+       type boolean;
+     }
+
+     leaf controller {
+       description "controller name";
+       type string;
+     }
+
+     leaf drop-count {
+       description "number of packets dropped for this classification";
+        type uint32;
+     }
+  }
+
+  container drop-counts {
+     list packet-ddrops {
+        description "drop counts for packets in different classes, Packets that violate access rules are logged here. ";
+        uses class-drop-count;
+     }
+  }
+
+
+
+  grouping l3l4info {
+     description "Various L3/L4 information that might cause a drop."
+     leaf ipsrc {
+        type inet:ip-address;
+        description
+           "Source IP address (v4 or v6).";
+        }
+     leaf protocol {
+          type uint8;
+          description "TCP, UDP, ICMP, ...";
+     }
+     leaf ipdst {
+        type inet:ip-address;
+        description
+           "Source IP address (v4 or v6).";
+     }
+     leaf l4srcport {
+          type uint16;
+          description "source port";
+     }
+     leaf l4dstport {
+
+
+
+Lear & Ranganathan      Expires December 29, 2019              [Page 10]
+
+Internet-Draft                MUD Reporter                     June 2019
+
+
+          type uint16;
+          description "destination port";
       }
    }
  }
- <CODE ENDS>
+}
+<CODE ENDS>
 
-2.3.  Operational matters
+3.  RESTful interface at the collector
+
+   <CODE BEGINS>file "ietf-mud-repor-collector@2019-06-21.yang"
+   module mud-reporter-collector {
+       import ietf-mud-reporter {
+           prefix "reporter";
+       }
+       rpc post-mud-report {
+         description
+            "Rpc interface that must be supported by collection point
+         input {
+           leaf mud-report {
+               type reporter:mud-reporter;
+           }
+         }
+       }
+   }
+   <CODE ENDS>
+
+4.  Examples
+
+   TBD
+
+5.  Privacy Considerations
+
+   Using this reporting mechanisms does not reveal internal IP
+   addresses.  Instead, it simply indicates whether a given abstraction
+   is in use, and how many instances there are.  What is revealed to the
+   manufacturer is that one or more devices reporting a particular MUD-
+   URL is located at a particular deployment.  In addition, as of this
+   draft, reportable events include only administratively dropped
+   packets, and the times they were dropped.
 
    In order to report the sorts of errors discussed in this memo, a
    deployment must determine which packets from a given device have
    either been or would be dropped due to an administrative filter rule.
 
-3.  Examples
 
-   TBD
 
-4.  Security Considerations
+
+
+
+
+Lear & Ranganathan      Expires December 29, 2019              [Page 11]
+
+Internet-Draft                MUD Reporter                     June 2019
+
+
+6.  Security Considerations
 
    All security considerations of [RFC8520] apply equally to this
    extension.  In addition, some care should be given to claims that a
@@ -487,24 +637,14 @@ Internet-Draft                MUD Reporter                     June 2019
      Standard reference: This document
 
 
-5.  References
+7.  References
 
-5.1.  Normative References
+7.1.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
-
-
-
-
-
-
-Lear                    Expires December 23, 2019               [Page 9]
-
-Internet-Draft                MUD Reporter                     June 2019
-
 
    [RFC6991]  Schoenwaelder, J., Ed., "Common YANG Data Types",
               RFC 6991, DOI 10.17487/RFC6991, July 2013,
@@ -519,12 +659,20 @@ Internet-Draft                MUD Reporter                     June 2019
               DOI 10.17487/RFC8520, March 2019,
               <https://www.rfc-editor.org/info/rfc8520>.
 
-5.2.  Informative References
+7.2.  Informative References
 
    [RFC7489]  Kucherawy, M., Ed. and E. Zwicky, Ed., "Domain-based
               Message Authentication, Reporting, and Conformance
               (DMARC)", RFC 7489, DOI 10.17487/RFC7489, March 2015,
               <https://www.rfc-editor.org/info/rfc7489>.
+
+
+
+
+Lear & Ranganathan      Expires December 29, 2019              [Page 12]
+
+Internet-Draft                MUD Reporter                     June 2019
+
 
 Appendix A.  Changes from Earlier Versions
 
@@ -532,7 +680,7 @@ Appendix A.  Changes from Earlier Versions
 
    o  Initial revision
 
-Author's Address
+Authors' Addresses
 
    Eliot Lear
    Cisco Systems
@@ -544,6 +692,14 @@ Author's Address
    Email: lear@cisco.com
 
 
+   Mudumbai Ranganathan
+   National Institute of Standards and Technology
+   100 Bureau Dr.
+   Gaithersburg
+   U.S.A
+
+   Phone: +1 301 975 2857
+   Email: mranga@nist.gov
 
 
 
@@ -557,4 +713,16 @@ Author's Address
 
 
 
-Lear                    Expires December 23, 2019              [Page 10]
+
+
+
+
+
+
+
+
+
+
+
+
+Lear & Ranganathan      Expires December 29, 2019              [Page 13]


### PR DESCRIPTION
I added a container to report ACL violation dropped packets. I am not sure how the l3l4info is going to be used.  The YANG model was fixed (I think some parens missing). Please check and let me know you agree with these changes. Thanks, Ranga